### PR TITLE
Update dkan_featured_topics.css

### DIFF
--- a/dkan_featured_topics.css
+++ b/dkan_featured_topics.css
@@ -4,13 +4,13 @@ body .navbar-default .navbar-nav .dropdown-menu, .navbar-default .user-menu .dro
   border-top-right-radius: 0;
   border-top-left-radius: 0;
 }
-.open .dropdown-menu {
+.navbar-nav .open .dropdown-menu {
   display: block;
 }
-.dropdown-menu a {
+.navbar-nav .dropdown-menu a {
   color: #2b3076 !important;
 }
-.dropdown-menu li.topics-item {
+.navbar-nav .dropdown-menu li.topics-item {
   float: left;
   width: 125px;
   height: 140px;
@@ -19,7 +19,7 @@ body .navbar-default .navbar-nav .dropdown-menu, .navbar-default .user-menu .dro
 .navbar-nav > li > .dropdown-menu.topics {
   padding: 30px;
 }
-.dropdown-menu.topics img {
+.navbar-nav .dropdown-menu.topics img {
   width: 75px;
   height: 75px;
 }
@@ -41,7 +41,7 @@ body .navbar-default .navbar-nav .dropdown-menu, .navbar-default .user-menu .dro
   .navbar-nav > li.open {
     position: static;
   }
-  .dropdown-menu {
+  .navbar-nav .dropdown-menu {
     width: 950px;
     float: left;
     left: 0;

--- a/dkan_featured_topics.features.field_base.inc
+++ b/dkan_featured_topics.features.field_base.inc
@@ -13,7 +13,7 @@ function dkan_featured_topics_field_default_field_bases() {
   // Exported field_base: 'field_topic'
   $field_bases['field_topic'] = array(
     'active' => 1,
-    'cardinality' => 1,
+    'cardinality' => -1,
     'deleted' => 0,
     'entity_types' => array(),
     'field_name' => 'field_topic',

--- a/dkan_featured_topics.features.field_instance.inc
+++ b/dkan_featured_topics.features.field_instance.inc
@@ -33,7 +33,7 @@ function dkan_featured_topics_field_default_field_instances() {
     ),
     'entity_type' => 'node',
     'field_name' => 'field_topic',
-    'label' => 'Topic',
+    'label' => 'Topics',
     'required' => 0,
     'settings' => array(
       'user_register_form' => FALSE,


### PR DESCRIPTION
Make the styles for the dropdown only affect the navbar dropdown

Needs work. This update will keep the rest of the bootstrap dropdowns from getting oversized to 950px wide but the menu toggle is now broken.
